### PR TITLE
Switch to new GPT-4o 2024-08-06

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-.api_key
+.api_key*
 __pycache__
 *.pyc

--- a/core.py
+++ b/core.py
@@ -3,12 +3,12 @@ from dataclasses import dataclass
 
 import openai
 
-MODEL = "gpt-4o"
+MODEL = "gpt-4o-2024-08-06"
 
 # GPT-4o prices in USD, source:
-# https://openai.com/pricing#language-models
-USD_PER_INPUT_TOKEN = 5e-6
-USD_PER_OUTPUT_TOKEN = 15e-6
+# https://openai.com/api/pricing/
+USD_PER_INPUT_TOKEN = 2.5e-6
+USD_PER_OUTPUT_TOKEN = 10e-6
 
 TEMPERATURE = 0.1
 


### PR DESCRIPTION
The new model is half the price, support something called [Structured outputs](https://platform.openai.com/docs/guides/structured-outputs/examples) that can be interesting to investigate.

> yes this new version isnt just cheaper its also much smarter too

From: https://www.reddit.com/r/singularity/comments/1elpx3c/um_did_openai_silently_drop_a_new_model/

Let's see if this is not a big deal, from my testing it does not seem so:

> Prompts that gpt-4o-2024-05-13 will do, gpt-4o-2024-08-06 won't.

From: https://www.reddit.com/r/singularity/comments/1elxcg6/gpt4o20240806_is_extremely_restrictive/