### PR TITLE
Take advantage of OpenAI provided shortcut for the latest model

### DIFF
--- a/core.py
+++ b/core.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 import openai
 
-MODEL = "gpt-4o-2024-08-06"
+MODEL = "chatgpt-4o-latest"
 
 # GPT-4o prices in USD, source:
 # https://openai.com/api/pricing/


### PR DESCRIPTION
We want to use the latest and greatest model. There is downside that model is going to change without us even knowing about that.

Thus: https://github.com/ChaoticRoman/chatgpt-gui/issues/42